### PR TITLE
Bump hyperloglog dependencies

### DIFF
--- a/subhask.cabal
+++ b/subhask.cabal
@@ -171,7 +171,7 @@ library
         MonadRandom     >= 0.1.13,
 
         -- required for hyperloglog compatibility
-        semigroups      == 0.16.2,
+        semigroups      == 0.16.2.2,
         bytes           == 0.15,
         approximate     == 0.2.1.1,
         lens            == 4.9.1,
@@ -248,8 +248,8 @@ Test-Suite TestSuite
         MonadRandom     >= 0.1.13,
 
         -- required for hyperloglog compatibility
-        semigroups      == 0.16.2,
-        bytes           == 0.14.1.3,
+        semigroups      == 0.16.2.2,
+        bytes           == 0.15,
         approximate     == 0.2.1.1,
         lens            == 4.9.1,
 


### PR DESCRIPTION
This brings the dependencies into line with the stackage nightly constraints: https://www.stackage.org/nightly as at 2015-05-22