### PR TITLE
Added "default-language:" to all targets in cabal file.

### DIFF
--- a/subhask.cabal
+++ b/subhask.cabal
@@ -166,6 +166,7 @@ library
 --------------------------------------------------------------------------------
 
 Test-Suite TestSuite-Unoptimized
+    default-language:   Haskell2010
     type:               exitcode-stdio-1.0
     hs-source-dirs:     test
     main-is:            TestSuite.hs
@@ -183,6 +184,7 @@ Test-Suite TestSuite-Unoptimized
 -- The slow builds are causing travis tests to fail.
 --
 -- Test-Suite TestSuite-Optimized
+--     default-language:   Haskell2010
 --     type:               exitcode-stdio-1.0
 --     hs-source-dirs:     test
 --     main-is:            TestSuite.hs
@@ -199,18 +201,21 @@ Test-Suite TestSuite-Unoptimized
 --------------------
 
 Test-Suite Example0001
+    default-language:   Haskell2010
     type:               exitcode-stdio-1.0
     hs-source-dirs:     examples
     main-is:            example0001-polynomials.lhs
     build-depends:      subhask, base
 
 Test-Suite Example0002
+    default-language:   Haskell2010
     type:               exitcode-stdio-1.0
     hs-source-dirs:     examples
     main-is:            example0002-monad-instances-for-set.lhs
     build-depends:      subhask, base
 
 Test-Suite Example0003
+    default-language:   Haskell2010
     type:               exitcode-stdio-1.0
     hs-source-dirs:     examples
     main-is:            example0003-linear-algebra.lhs
@@ -219,6 +224,7 @@ Test-Suite Example0003
 --------------------------------------------------------------------------------
 
 benchmark Vector
+    default-language: Haskell2010
     type:             exitcode-stdio-1.0
     hs-source-dirs:   bench
     main-is:          Vector.hs


### PR DESCRIPTION
Without this, cabal gives a warning:

```
$ cabal test
./subhask.cabal has been changed. Re-configuring with most recently used
options. If this fails, please run configure manually.
Resolving dependencies...
Configuring subhask-0.1.0.1...
Warning: Packages using 'cabal-version: >= 1.10' must specify the
'default-language' field for each component (e.g. Haskell98 or Haskell2010).
If a component uses different languages in different modules then list the
other ones in the 'other-languages' field.
Preprocessing library subhask-0.1.0.1...
[ 1 of 36] Compiling SubHask.TemplateHaskell.Common ( src/SubHask/TemplateHaskell/Common.hs, dist/build/SubHask/TemplateHaskell/Common.o )
...
```