### PR TITLE
Remove overlapping pattern match.

### DIFF
--- a/src/SubHask/TemplateHaskell/Deriving.hs
+++ b/src/SubHask/TemplateHaskell/Deriving.hs
@@ -285,6 +285,7 @@ substituteNewtype conname varname newvar = go
 typeL2patL :: Name -> Name -> [Type] -> [Pat]
 typeL2patL conname varname xs = map go $ zip (map (\a -> mkName [a]) ['a'..]) xs
     where
+        go :: (Name, Type) -> Pat
         go (newvar,VarT v) = if v==varname
             then ConP conname [VarP newvar]
             else VarP newvar
@@ -296,8 +297,6 @@ typeL2patL conname varname xs = map go $ zip (map (\a -> mkName [a]) ['a'..]) xs
         go (newvar,AppT ListT (AppT (ConT _) (VarT v))) = VarP newvar
         go (newvar,ConT c) = VarP newvar
         go (newvar,_) = VarP newvar
-
-        go qqq = error $ "qqq="++show qqq
 
 typeL2expL :: [Type] -> [Exp]
 typeL2expL xs = map fst $ zip (map (\a -> VarE $ mkName [a]) ['a'..]) xs


### PR DESCRIPTION
This removes an unreachable pattern match.  It also adds a type signature on a function in a where clause, hopefully making the code more readable.

The following warning occurs without this change:

```
$ cabal build
...
[ 7 of 36] Compiling SubHask.TemplateHaskell.Deriving ( src/SubHask/TemplateHaskell/Deriving.hs, dist/build/SubHask/TemplateHaskell/Deriving.o )

src/SubHask/TemplateHaskell/Deriving.hs:289:9: Warning:
    Pattern match(es) are overlapped
    In an equation for ‘go’: go qqq = ...
```