### PR TITLE
Add some missing laws/theorems/definitions to the test suite.

### DIFF
--- a/src/SubHask/Algebra.hs
+++ b/src/SubHask/Algebra.hs
@@ -14,6 +14,7 @@ module SubHask.Algebra
     , law_Eq_reflexive
     , law_Eq_symmetric
     , law_Eq_transitive
+    , defn_Eq_noteq
     , POrd_ (..)
     , POrd
     , law_POrd_commutative

--- a/src/SubHask/TemplateHaskell/Test.hs
+++ b/src/SubHask/TemplateHaskell/Test.hs
@@ -32,6 +32,7 @@ testMap = Map.fromList
         [ "law_Eq_reflexive"
         , "law_Eq_symmetric"
         , "law_Eq_transitive"
+        , "defn_Eq_noteq"
         ] )
     , ( "POrd_",
         [ "law_POrd_commutative"
@@ -44,6 +45,13 @@ testMap = Map.fromList
     , ( "Lattice_",
         [ "law_Lattice_infabsorption"
         , "law_Lattice_supabsorption"
+        , "law_Lattice_antisymmetry"
+        , "law_Lattice_associative"
+        , "law_Lattice_commutative"
+        , "law_Lattice_reflexivity"
+        , "law_Lattice_transitivity"
+        , "theorem_Lattice_idempotent"
+        , "defn_Lattice_greaterthan"
         ] )
     , ( "Ord_",
         [ "law_Ord_totality"


### PR DESCRIPTION
Some laws, theorems, and definitions were left out of the test suite.
This commit adds them back in:

```
law_Lattice_antisymmetry
law_Lattice_associative
law_Lattice_commutative
law_Lattice_reflexivity
law_Lattice_transitivity

theorem_Lattice_idempotent

defn_Eq_noteq
defn_Lattice_greaterthan
```

This fixes part of issue #19.