### PR TITLE
Minor example updates

### DIFF
--- a/examples/example0003-linear-algebra.lhs
+++ b/examples/example0003-linear-algebra.lhs
@@ -111,7 +111,7 @@ Let's create two vectors and show all the vector operations you might want to pe
 >   putStrLn $ "scalar mul:    " + show (5  *. u)
 >   putStrLn $ "component mul: " + show (u .*. v)
 
-Because `SVector` is not just a vector space but also a hilbert space (i.e. instance of `Hilbert`),
+Because `SVector` is not just a vector space but also a [hilbert space][hilbert-wiki] (i.e. instance of `Hilbert`),
 we get the following operations as well:
 
 >   putStrLn ""
@@ -134,7 +134,8 @@ which also means that we can go about representing a matrix as two `SVector`s co
 >   putStrLn $ "matrix1.matrix1 = " + show (matrix1.matrix1)
 
 Square matrices (as shown above) are instances of the `Ring` type class.
-But non-square matrices cannot be made instances of `Ring`.
+But non-square matrices cannot be made instances of `Ring`
+-- for more information on the ring algebraic structure, [see here][ring-wiki].
 The reason is that the type signature for multiplication
 ```
 (*) :: Ring r => r -> r -> r
@@ -158,14 +159,14 @@ Here's an example:
 >   putStrLn $ "b.a     = " + show (b.a)
 >   putStrLn $ "b.c.c.a = " + show (b.c.c.a)
 
-Linear functions form a subcategory of Hask,
+Linear functions form a [subcategory of Hask][LinearObjects.hs],
 and function application corresponds to right multiplying by a vector:
 
 >   putStrLn ""
 >   putStrLn $ "c $ u = " + show (c $ u)
 
 Linear functions form what's known as a dagger catgory (i.e. `(+>)` is an instance of `Dagger`).
-Dagger categories capture the idea of transposing a function and the ability to left multiply a vector.
+[Dagger categories][dagger-wiki] capture the idea of transposing a function and the ability to left multiply a vector.
 
 >   putStrLn ""
 >   putStrLn $ "trans c = " + show (trans c)
@@ -208,3 +209,9 @@ These multiparameter functions correspond to higher order tensors.
 The reason for this limitation is type system issues I haven't figured out.
 
 There are many more FIXME annotations documented in the code.
+
+[LinearObjects.hs]: https://github.com/mikeizbicki/subhask/blob/master/src/SubHask/Category/Linear/Objects.hs
+[dagger-wiki]: https://en.wikipedia.org/wiki/Dagger_category
+[ring-wiki]: https://en.wikipedia.org/wiki/Ring_(mathematics)
+[hilbert-wiki]: https://en.wikipedia.org/wiki/Hilbert_space
+

--- a/examples/example0003-linear-algebra.lhs
+++ b/examples/example0003-linear-algebra.lhs
@@ -1,5 +1,5 @@
 This example introduces subhask's basic linear algebra system.
-It starts with the differences between arrays and vectors,
+It starts with the differences between arrays and vectors, 
 then shows example manipulations on a few vector spaces,
 and concludes with links to real world code.
 
@@ -27,9 +27,9 @@ Arrays vs. Vectors
 
 Vectors are the heart of linear algebra.
 But before we talk about vectors, we need to talk about containers.
-In particular, arrays and vectors are different in subhask.
-Arrays are generic containers suitable for storing both numeric and non-numeric values.
-Vectors are elements of a vector space and come with a completely different set of laws.
+In particular, arrays and vectors are different in Subhask than in most standard libraries.
+In the context of Subhask; arrays are generic containers suitable for storing both numeric and non-numeric values -
+while vectors are elements of a vector space and come with a completely different set of laws.
 
 There are three different types of arrays, each represented differently in memory.
 The `BArray` is a boxed array, `UArray` is an unboxed array, and `SArray` is a storable array.
@@ -50,7 +50,7 @@ We construct vectors using the `unsafeToModule` function.
 >   putStrLn $ "vec  = " + show vec
 
 If the dimension of the vector is not known at compile time, it does not need to be specified in the type signature.
-Instead, you can provide a string that represents the size of the vector.
+Instead, you can provide a string annotation in the type which will represent -- or act as a reference to -- it's size.
 
 >   let vec' = unsafeToModule [1..5] :: SVector "datapoint" Double
 >
@@ -58,7 +58,7 @@ Instead, you can provide a string that represents the size of the vector.
 
 The laws of the `Constructible` class, ensure that the `Monoid` instance concatenates two containers together.
 Vectors are not `Constructible` because their `Monoid` instance is not concatenation.
-Instead, is is componentwise addition on each of the elements.
+Instead, it is component-wise addition on each of the elements.
 Compare the following:
 
 >   putStrLn ""
@@ -67,11 +67,11 @@ Compare the following:
 >   putStrLn $ "vec' + vec' = " + (show $ vec'+vec')
 
 One commonality between vectors and arrays is that they are both indexed containers (i.e. instances of `IxContainer`).
-This lets us look up a value at a specific instance using the `(!)` operator:
+This lets us look up a value in a specific instance using the `(!)` operator:
 
 >   putStrLn ""
->   putStrLn $ "arr!0  = " + show (arr!0)
->   putStrLn $ "vec!0  = " + show (vec!0)
+>   putStrLn $ "arr !0 = " + show (arr !0)
+>   putStrLn $ "vec !0 = " + show (vec !0)
 >   putStrLn $ "vec'!0 = " + show (vec'!0)
 
 Unboxed arrays in subhask are more powerful than the unboxed vectors used in standard haskell.
@@ -92,7 +92,8 @@ Nonetheless, because we have annotated the sizes with different strings, the fol
 ```
 
 And this is exactly what we want!
-It doesn't make sense to add a vector of dimension 2 to a vector of dimension 3, so the types prevent it.
+It doesn't make sense to add a vector of dimension 2 to a vector of dimension 3 however we, ourselves, may not know what kind of dimentionality we are dealing with.
+Instead of requiring the us to have this knowledge, we can offload the work to the type system to prevent this!
 
 I've found this distinction between vectors and arrays greatly simplifies the syntax when using linear algebra.
 
@@ -105,10 +106,10 @@ Let's create two vectors and show all the vector operations you might want to pe
 >       v = unsafeToModule [0,1,2] :: SVector 3 Double
 >
 >   putStrLn ""
->   putStrLn $ "add:           " + show (u+v)
->   putStrLn $ "sub:           " + show (u-v)
->   putStrLn $ "scalar mul:    " + show (5*.u)
->   putStrLn $ "component mul: " + show (u.*.v)
+>   putStrLn $ "add:           " + show (u + v)
+>   putStrLn $ "sub:           " + show (u - v)
+>   putStrLn $ "scalar mul:    " + show (5  *. u)
+>   putStrLn $ "component mul: " + show (u .*. v)
 
 Because `SVector` is not just a vector space but also a hilbert space (i.e. instance of `Hilbert`),
 we get the following operations as well:
@@ -116,16 +117,17 @@ we get the following operations as well:
 >   putStrLn ""
 >   putStrLn $ "norm:          " + show (size u)
 >   putStrLn $ "distance:      " + show (distance u v)
->   putStrLn $ "inner product: " + show (u<>v)
->   putStrLn $ "outer product: " + show (u><v)
+>   putStrLn $ "inner product: " + show (u <> v)
+>   putStrLn $ "outer product: " + show (u >< v)
 
-The usual way people think of the outer product of two vectors is as a matrix.
+Usually, people think of the outer product of two vectors is as a matrix.
 But matrices are equivalent to linear functions, and that's the interpretation used in subhask.
 The category `(+>)` (also called `Vect`) is the subcategory of `Hask` corresponding to linear functions.
 
-The main advantage of this interpretation is that matrix multiplication is the same thing as function composition.
+The main advantage of this interpretation is that matrix multiplication becomes the same as function composition,
+which also means that we can go about representing a matrix as two `SVector`s composed together with `(+>)`.
 
->   let matrix1 = u><v :: SVector 3 Double +> SVector 3 Double
+>   let matrix1 = u >< v :: SVector 3 Double +> SVector 3 Double
 >
 >   putStrLn ""
 >   putStrLn $ "matrix1*matrix1 = " + show (matrix1*matrix1)
@@ -175,7 +177,7 @@ and ordinary haskell functions are actually infinite dimensional vector space!
 Here they are in action:
 
 >   let f x = x.*.x -- :: SVector 5 Double
->       g x = x+x   -- :: SVector 5 Double
+>       g x = x + x -- :: SVector 5 Double
 >
 >   let h = f.*.g   -- :: SVector 5 Double -> SVector 5 Double
 >

--- a/examples/example0003-linear-algebra.lhs
+++ b/examples/example0003-linear-algebra.lhs
@@ -51,6 +51,7 @@ We construct vectors using the `unsafeToModule` function.
 
 If the dimension of the vector is not known at compile time, it does not need to be specified in the type signature.
 Instead, you can provide a string annotation in the type which will represent -- or act as a reference to -- it's size.
+In addition, you can use any number of strings to reference the same size -- allowing for more flexible type signatures.
 
 >   let vec' = unsafeToModule [1..5] :: SVector "datapoint" Double
 >


### PR DESCRIPTION
Hi @mikeizbicki — added some minor grammar / syntax tweaks as I was going through the first example. Feel free to ask for a subset of these if you don't agree with some of these changes.

Peanut gallery questions:
+ what if we have two strings that reference vector size which we want to alias -- is this possible?
+ how do you hyperlink text in literate haskell?
+ are you partial to literate haskell? It seems like we might be able to use [IHaskell][ihask] in the same interactive/reproducible way you are developing these examples, but we would also have these examples render in github and we could also use markdown (which seems more widespread than literate haskell).

[ihask]:https://github.com/gibiansky/IHaskell/blob/master/notebooks/Conjugate%20Gradient.ipynb