### PR TITLE
fix +> Category instance

### DIFF
--- a/examples/example0003-linear-algebra.lhs
+++ b/examples/example0003-linear-algebra.lhs
@@ -148,8 +148,8 @@ So the type system will ensure that your matrix multiplications actually make se
 
 Here's an example:
 
->   let a = unsafeMkSMatrix 2 3 [1..6] :: SVector "a" Double +> SVector 3   Double
->       b = unsafeMkSMatrix 3 2 [1..6] :: SVector 3   Double +> SVector "a" Double
+>   let a = unsafeMkSMatrix 3 2 [1..6] :: SVector "a" Double +> SVector 3   Double
+>       b = unsafeMkSMatrix 2 3 [1..6] :: SVector 3   Double +> SVector "a" Double
 >       c = unsafeMkSMatrix 3 3 [1..9] :: SVector 3   Double +> SVector 3   Double
 >
 >   putStrLn ""
@@ -161,6 +161,11 @@ and function application corresponds to right multiplying by a vector:
 
 >   putStrLn ""
 >   putStrLn $ "c $ u = " + show (c $ u)
+
+When thinking of linear functions as matrices, the type signature may be slightly confusing.
+A linear function that takes a vector of length n to a vector of length m corresponds to a matrix with n columns and m rows.
+Thus, the type `SVector 3 Double +> SVector 2 Double` is the type of a 2 by 3 matrix.
+The argument order of `unsafeMkSMatrix` is the standard "row, column" order, however.
 
 Linear functions form what's known as a dagger catgory (i.e. `(+>)` is an instance of `Dagger`).
 Dagger categories capture the idea of transposing a function and the ability to left multiply a vector.

--- a/src/SubHask/Algebra/Vector.hs
+++ b/src/SubHask/Algebra/Vector.hs
@@ -1661,7 +1661,7 @@ instance Category (+>) where
 
     (Mat_ m1) . Zero      = Zero
     (Mat_ m ) . (Id_  r ) = Mat_ $ HM.scale r m
-    (Mat_ m1) . (Mat_ m2) = Mat_ $ m2 HM.<> m1
+    (Mat_ m1) . (Mat_ m2) = Mat_ $ m1 HM.<> m2
 
 instance Sup (+>) (->) (->)
 instance Sup (->) (+>) (->)


### PR DESCRIPTION
@mikeizbicki,

While working through the linear algebra example, I found and fixed a bug in the `(+>)` Category instance that caused `(a.b) $ x` to not equal `a $ b $ x`. The problem is that the instance of Concrete assumes that the type `SVector 3 Double +> SVector 2 Double` describes a matrix with 3 columns and 2 rows, while the instance for Category assumes that it means 3 rows and 2 columns (the other way around!).  The linear algebra example file was using the latter convention exclusively, but it wasn't causing problems because `($)` was only used with square matrices, which masked the problem.

 Here's a minimal example of the problem for GHCI (adapted from the linear algebra example code):

```haskell
let x = unsafeToModule [2,1,0] :: SVector 3 Double
let a = unsafeMkSMatrix 2 3 [1..6] :: SVector 2 Double +> SVector 3 Double
let b = unsafeMkSMatrix 3 2 [1..6] :: SVector 3 Double +> SVector 2 Double
```

Then this will give the correct answer of [30,64,98] (I verified with Numpy as a sanity check):

```haskell
(a.b) $ x 
```

While this will result in an exception:

```haskell
a $ b $ x
```

This problem can also lead to type errors if we follow the row,column convention in the examples. `a` is actually the right shape to right-multiply by x, but `a $ x` is a type error.

After this fix, we will need to type our matrices the other way around:

```haskell
let a' = unsafeMkSMatrix 2 3 [1..6] :: SVector 3 Double +> SVector 2 Double

let b' = unsafeMkSMatrix 3 2 [1..6] :: SVector 2 Double +> SVector 3 Double
```

And then `(a'.b') $ x ` and `a' $ b' $ x` will both give correct results.

The underlying problem is that the implementation of `(.)` for matrices was flipped matrix multiplication, but it should be unflipped. That is, `(a . b)` should denote AB, not BA. This is the only way to get consistent behavior for `(.)` and `($)`. It also makes matrix multiplication in SubHask a lot less confusing :)

This PR also fixes the example and adds a note about how to read matrix type signatures w.r.t. numbers of rows and columns.

Unfortunately I wasn't able to figure out how to write a test for this. It looks like the Template Haskell test system only works for unary type classes. If you have any pointers, I can try to add a test to the PR. I wanted to write a test like this: 

```haskell
law_Concrete_application_composition ::
    (subcat <: (->)
     , Category subcat
     , Eq_ c) => subcat b c -> subcat a b -> a -> Logic c
law_Concrete_application_composition f g x
    = ((f.g) $ x) == (f $ g $ x)
```