### PR TITLE
[WIP] UVector algebra instances

### DIFF
--- a/src/SubHask/Algebra/Array.hs
+++ b/src/SubHask/Algebra/Array.hs
@@ -226,6 +226,7 @@ instance
     , Prim r
     , FreeModule r
     , IsScalar r
+    , ValidUVector s r
     ) => Constructible (UArray (UVector (s::Symbol) r))
         where
 
@@ -605,6 +606,7 @@ instance
     , IsScalar r
     , Prim y
     , Unbox y
+    , ValidUVector s r
     ) => Constructible (UArray (Labeled' (UVector (s::Symbol) r) y))
         where
 

--- a/src/SubHask/Algebra/Vector.hs
+++ b/src/SubHask/Algebra/Vector.hs
@@ -16,6 +16,7 @@
 module SubHask.Algebra.Vector
     ( SVector (..)
     , UVector (..)
+    , ValidUVector
     , Unbox
     , type (+>)
     , SMatrix
@@ -517,7 +518,6 @@ instance
             goEach !tot !i = if i<0
                 then tot
                 else goEach (tot + (v1!i-v2!i).*.(v1!i-v2!i)) (i-1)
-
 
 instance (VectorSpace r, Prim r, IsScalar r, ExpField r) => Normed (UVector (n::Symbol) r) where
     {-# INLINE size #-}


### PR DESCRIPTION
I had a go at adding some algebra instances for UVector.  My motivation is to be able to say:

    λ> let v1 = unsafeToModule [1..7] :: UVector "x" Double
    λ> let sphere v = (v.+(-1)) <> (v.+(-1))
    λ> sphere v1
    91.0

The Action instance was easy but the <> proved to be tougher.  Hilbert needed a TensorAlgebra instance of UVector (does it have to?) and this had a knock on effect so I ended up having to create some of the matrix heirarchy.

I saw along the way that the TensorAlgebra class `needs to be replaced by the Tensor product in the Monoidal category Vect`.  It all looked like a big refactor well above my pay grade.

Once I created the Tensor_UVector family, I had to also create a ValidUVector type and then use it in a lot of places, also having to export it for use in Algebra.  Is this usually how it goes when developing the algebra instances?

It looked like the ToFromVector constraint in unsafeMkSMatrix and the MatrixField instance of SVector was for convenience.  I created a ToFromVector instance for UVector but left it undefined.  I wasn't sure whether to go with a ToFromSVector, ToFromUVector, or to combine them and also guessed they would be moving elsewhere eventually.

I also just copied unsafeMkUMatrix from the SVector version and didnt think about an efficient implementation of an Unboxed Matrix (but this would be an interesting mini-project).




