### PR TITLE
[WIP] Removed library constraints, and hmatrix fixes

### DIFF
--- a/src/SubHask/Compatibility/HyperLogLog.hs
+++ b/src/SubHask/Compatibility/HyperLogLog.hs
@@ -6,6 +6,7 @@ import SubHask.Category
 import SubHask.Internal.Prelude
 
 import qualified Data.HyperLogLog as H
+import qualified Data.Reflection as R
 import qualified Data.Semigroup as S
 import qualified Prelude as P
 
@@ -32,13 +33,13 @@ instance Semigroup (HyperLogLog p a) where
 instance Abelian (HyperLogLog p a)
 
 instance
-    ( H.ReifiesConfig p
+    ( R.Reifies p Integer
     ) => Normed (HyperLogLog p a)
         where
     size (H h) = P.fromIntegral $ L.view A.estimate (H.size h)
 
 instance
-    ( H.ReifiesConfig p
+    ( R.Reifies p Integer
     , S.Serial a
     ) => Constructible (HyperLogLog p a)
         where

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,4 +6,4 @@ extra-deps:
     , continued-fractions-0.9.1.1
     , converge-0.1.0.1
     ]
-resolver: lts-3.3
+resolver: lts-5.9

--- a/subhask.cabal
+++ b/subhask.cabal
@@ -124,40 +124,41 @@ library
         -- But since subhask is designed as an alternative to base, this is an acceptable tradeoff.
 
         -- haskell language
-        base                        >= 4.8 && <4.9,
-        ghc-prim                    == 0.4.0.0,
-        template-haskell            == 2.10.0.0,
+        base                        ,
+        ghc-prim                    ,
+        template-haskell            ,
 
         -- special functionality
-        parallel                    == 3.2.0.6,
-        deepseq                     == 1.4.1.1,
-        primitive                   == 0.6,
-        monad-primitive             == 0.1,
-        QuickCheck                  == 2.8.1,
+        parallel                    ,
+        deepseq                     ,
+        primitive                   ,
+        monad-primitive             ,
+        QuickCheck                  ,
 
         -- math
-        erf                         == 2.0.0.0,
-        gamma                       == 0.9.0.2,
-        hmatrix                     == 0.16.1.5,
+        erf                         ,
+        gamma                       ,
+        hmatrix                     ,
 
         -- compatibility control flow
-        mtl                         == 2.2.1,
-        MonadRandom                 == 0.4,
+        mtl                         ,
+        MonadRandom                 ,
 
         -- compatibility data structures
-        bytestring                  == 0.10.6.0,
-        bloomfilter                 == 2.0.1.0,
-        cassava                     == 0.4.3.1,
-        containers                  == 0.5.6.2,
-        vector                      == 0.10.12.3,
-        array                       == 0.5.1.0,
-        hyperloglog                 == 0.3.4,
+        bytestring                  ,
+        bloomfilter                 ,
+        cassava                     ,
+        containers                  ,
+        vector                      ,
+        array                       ,
+        hyperloglog                 ,
+        reflection                  ,
 
         -- required for hyperloglog compatibility
-        semigroups                  == 0.16.2.2,
-        bytes                       == 0.15.0.1,
-        approximate                 == 0.2.2.1,
-        lens                        == 4.12.3
+        semigroups                  ,
+        bytes                       ,
+        approximate                 ,
+        lens                        
 
     default-language:
         Haskell2010
@@ -175,8 +176,8 @@ Test-Suite TestSuite-Unoptimized
 
     build-depends:
         subhask,
-        test-framework-quickcheck2  >= 0.3.0,
-        test-framework              >= 0.8.0
+        test-framework-quickcheck2,
+        test-framework
 
 -- FIXME:
 -- The test below takes a long time to compile.
@@ -230,7 +231,7 @@ benchmark Vector
     build-depends:
         base,
         subhask,
-        criterion                   == 1.1.0.0,
+        criterion,
         MonadRandom
 
     ghc-options:

--- a/subhask.cabal
+++ b/subhask.cabal
@@ -124,7 +124,7 @@ library
         -- But since subhask is designed as an alternative to base, this is an acceptable tradeoff.
 
         -- haskell language
-        base                        ,
+        base                        >= 4.8 && <4.9,
         ghc-prim                    ,
         template-haskell            ,
 


### PR DESCRIPTION
Refer #27 

Compiling, testing ok, and no noticable performance regressions with library constraints removed and lts-5.9 as the resolver.

- I had to spam a `P.Num (HM.Vector r)` constraint everywhere as a result of the API changes in HMatrix - there could well be a one spot solution.

- The Mul class in HMatrix has been removed (ie you can no longer say Matrix <> Vector) which necessitated some extra code in apMat_.

- HyperLogLog API has changed slightly and the result was needing an additional dependency on Reflection.
