### PR TITLE
Remove question about whether Heyting algebras are cancellative semigroups.

### DIFF
--- a/src/SubHask/Algebra.hs
+++ b/src/SubHask/Algebra.hs
@@ -928,10 +928,6 @@ instance Complemented b => Complemented (a -> b) where
 
 -- | Heyting algebras are lattices that support implication, but not necessarily the law of excluded middle.
 --
--- FIXME:
--- Is every Heyting algebra a cancellative Abelian semigroup?
--- If so, should we make that explicit in the class hierarchy?
---
 -- ==== Laws
 -- There is a single, simple law that Heyting algebras must satisfy:
 --
@@ -943,6 +939,8 @@ instance Complemented b => Complemented (a -> b) where
 -- distributivity
 --
 -- See <https://en.wikipedia.org/wiki/Heyting_algebra wikipedia> for more details.
+--
+-- Note that while Heyting algebras are abelian semigroups with respect to ⋀, they are not necessarily cancellative.
 class Bounded b => Heyting b where
     -- | FIXME: think carefully about infix
     infixl 3 ==>

--- a/src/SubHask/Algebra.hs
+++ b/src/SubHask/Algebra.hs
@@ -940,7 +940,7 @@ instance Complemented b => Complemented (a -> b) where
 --
 -- See <https://en.wikipedia.org/wiki/Heyting_algebra wikipedia> for more details.
 --
--- Note that while Heyting algebras are abelian semigroups with respect to ⋀, they are not necessarily cancellative.
+-- Note that while Heyting algebras are abelian semigroups with respect to ⋀, they are not in general cancellative.
 class Bounded b => Heyting b where
     -- | FIXME: think carefully about infix
     infixl 3 ==>

--- a/src/SubHask/Algebra.hs
+++ b/src/SubHask/Algebra.hs
@@ -940,7 +940,7 @@ instance Complemented b => Complemented (a -> b) where
 --
 -- See <https://en.wikipedia.org/wiki/Heyting_algebra wikipedia> for more details.
 --
--- Note that while Heyting algebras are abelian semigroups with respect to ⋀, they are not in general cancellative.
+-- Note that while Heyting algebras are abelian semigroups with respect to &&, they are not in general cancellative.
 class Bounded b => Heyting b where
     -- | FIXME: think carefully about infix
     infixl 3 ==>


### PR DESCRIPTION
Also add a comment that they're not cancellative in general, in case the
question arises again. (Counterexample: open intervals in R.)

This resolves #34. I'm not sure it's worth including the counterexample in the note. (Or even the note for that matter. It seems worth noting if the example of a Heyting algebra that springs to mind in this context is cancellative. Of course, I don't know what that example is.)