### PR TITLE
Travis refactor (llvm off)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,57 +1,90 @@
+# see https://github.com/hvr/multi-ghc-travis for structure
+
+# Use new container infrastructure to enable caching
+sudo: false
+
 # NB: don't set `language: haskell` here
+language: c
 
-# The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
-env:
- - CABALVER=1.22 GHCVER=7.10.1 LLVMVER=3.5
- - CABALVER=1.22 GHCVER=7.10.2 LLVMVER=3.5
- # - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
+# The different configurations we want to test.
+matrix:
+  include:
+  
+  - env: BUILD=stack ARGS="--resolver lts-6"
+    compiler: ": #stack 7.10.3"
+    addons: {apt: {packages: [ghc-7.10.3, libblas-dev, liblapack-dev, g++-4.8], sources: [hvr-ghc, ubuntu-toolchain-r-test]}}
 
-# Note: the distinction between `before_install` and `install` is not important.
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.ghc
+  - $HOME/.cabal
+  - $HOME/.stack
+
 before_install:
+# Using compiler above sets CC to an invalid value, so unset it
+- unset CC
 
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
- - travis_retry sudo apt-get install libblas-dev liblapack-dev
+# We want to always allow newer versions of packages when building on GHC HEAD
+- CABALARGS=""
+- if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
 
- # update g++
- - g++ --version
- - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
- - sudo apt-get update -qq
- - sudo apt-get install -qq g++-4.8
- - g++ --version
- - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
- - g++ --version
-
- # update llvm
- - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
- - travis_retry sudo add-apt-repository "deb http://llvm.org/apt/precise/ llvm-toolchain-precise main"
- - travis_retry sudo add-apt-repository "deb http://llvm.org/apt/precise/ llvm-toolchain-precise-$LLVMVER main"
- - travis_retry sudo apt-get update
- - sudo apt-get install -y llvm-$LLVMVER llvm-$LLVMVER-dev
- #- sudo ln -s /usr/bin/opt-$LLVMVER /usr/bin/opt
- - sudo rm -rf /usr/bin/opt && sudo ln -s /usr/bin/opt-$LLVMVER /usr/bin/opt
- - sudo rm -rf /usr/bin/llc && sudo ln -s /usr/bin/llc-$LLVMVER /usr/bin/llc
- - export PATH="/usr/bin:$PATH"
+# Download and unpack the stack executable
+- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
+- mkdir -p ~/.local/bin
+- |
+  if [ `uname` = "Darwin" ]
+  then
+    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+  else
+    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  fi
+  # Use the more reliable S3 mirror of Hackage
+  mkdir -p $HOME/.cabal
+  echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
+  echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
+  if [ "$CABALVER" != "1.16" ]
+  then
+    echo 'jobs: $ncpus' >> $HOME/.cabal/config
+  fi
+# Get the list of packages from the stack.yaml file
+- PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@')
 
 install:
- - cabal --version
- - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - travis_retry cabal update
- - travis_retry cabal install -j4 --only-dependencies --enable-tests --enable-benchmarks
-
-# Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
+- echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+- if [ -f configure.ac ]; then autoreconf -i; fi
+- |
+  set -ex
+  case "$BUILD" in
+    stack)
+      stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+      ;;
+    cabal)
+      cabal --version
+      travis_retry cabal update
+      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      ;;
+  esac
+  set +ex
 script:
- - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
- - cabal build   # this builds all libraries and executables (including tests/benchmarks)
- - cabal test
- - cabal check
- - cabal sdist   # tests that a source-distribution can be generated
-
-# Check that the resulting source distribution can be built & installed.
-# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
-# `cabal install --force-reinstalls dist/*-*.tar.gz`
- - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
-   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+- |
+  set -ex
+  case "$BUILD" in
+    stack)
+      stack --no-terminal $ARGS test --bench --no-run-benchmarks
+      ;;
+    cabal)
+      cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      ORIGDIR=$(pwd)
+      for dir in $PACKAGES
+      do
+        cd $dir
+        cabal check || [ "$CABALVER" == "1.16" ]
+        cabal sdist
+        SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz && \
+          (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+        cd $ORIGDIR
+      done
+      ;;
+  esac
+  set +ex

--- a/subhask.cabal
+++ b/subhask.cabal
@@ -18,7 +18,7 @@ description:
     For example, the category <http://ncatlab.org/nlab/show/Vect Vect> of linear functions is a subcategory of Hask, and SubHask exploits this fact to give a nice interface for linear algebra.
     To achieve this goal, almost every class hierarchy is redefined to be more general.
 
-    I recommend reading the <http://github.com/mikeizbicki/subhask/blob/master/README.md README> file and the <http://github.com/mikeizbicki/subhask/blob/master/examples examples> before looking at the documetation here.
+    I recommend reading the <http://github.com/mikeizbicki/subhask/blob/master/README.md README> file and the <http://github.com/mikeizbicki/subhask/blob/master/examples examples> before looking at the documentation here.
 
 source-repository head
     type: git
@@ -107,59 +107,49 @@ library
         cbits/Lebesgue.c
 
     cc-options:
---         -O3
         -ffast-math
         -msse3
 
     ghc-options:
---         -O2
---         -O
         -funbox-strict-fields
 
     build-depends:
-        -- NOTE:
-        -- We specify the *exact* versions of all non-base libraries to ensure that we get reproducible builds.
-        -- This helps prevent performance regressions.
-        -- The downside of exact version dependencies is that the user probably doesn't have these versions installed.
-        -- This can result in significantly longer build times and build conflicts.
-        -- But since subhask is designed as an alternative to base, this is an acceptable tradeoff.
-
         -- haskell language
-        base                        >= 4.8 && <4.9,
-        ghc-prim                    ,
-        template-haskell            ,
+        base >= 4.8 && <4.9,
+        ghc-prim,
+        template-haskell,
 
         -- special functionality
-        parallel                    ,
-        deepseq                     ,
-        primitive                   ,
-        monad-primitive             ,
-        QuickCheck                  ,
+        parallel,
+        deepseq,
+        primitive,
+        monad-primitive,
+        QuickCheck,
 
         -- math
-        erf                         ,
-        gamma                       ,
-        hmatrix                     ,
+        erf,
+        gamma,
+        hmatrix,
 
         -- compatibility control flow
-        mtl                         ,
-        MonadRandom                 ,
+        mtl,
+        MonadRandom,
 
         -- compatibility data structures
-        bytestring                  ,
-        bloomfilter                 ,
-        cassava                     ,
-        containers                  ,
-        vector                      ,
-        array                       ,
-        hyperloglog                 ,
-        reflection                  ,
+        bytestring,
+        bloomfilter,
+        cassava,
+        containers,
+        vector,
+        array,
+        hyperloglog,
+        reflection,
 
         -- required for hyperloglog compatibility
-        semigroups                  ,
-        bytes                       ,
-        approximate                 ,
-        lens                        
+        semigroups,
+        bytes,
+        approximate,
+        lens                 
 
     default-language:
         Haskell2010
@@ -239,31 +229,10 @@ benchmark Vector
         -O2
         -funbox-strict-fields
         -fexcess-precision
-
---         -fliberate-case-threshold=100000
---         -fexpose-all-unfoldings
---         -fmax-simplifier-iterations=10
---         -fmax-worker-args=100
---         -fsimplifier-phases=5
---         -fspec-constr-count=50
-
-        -fllvm
+        -- awaiting https://github.com/travis-ci/travis-ci/issues/6120
+        -- -fllvm
         -optlo-O3
         -optlo-enable-fp-mad
         -optlo-enable-no-infs-fp-math
         -optlo-enable-no-nans-fp-math
         -optlo-enable-unsafe-fp-math
-
---         -ddump-to-file
---         -ddump-rule-firings
---         -ddump-rule-rewrites
---         -ddump-rules
---         -ddump-cmm
---         -ddump-simpl
---         -ddump-simpl-stats
---         -dppr-debug
---         -dsuppress-module-prefixes
---         -dsuppress-uniques
---         -dsuppress-idinfo
---         -dsuppress-coercions
---         -dsuppress-type-applications


### PR DESCRIPTION
#38 
I targeted the new container-based travis (sudo: false) and it neatened up the code well.  Subject to llvm.

I had a good look through the whole llvm travis mess.  llvm have turned off support for apt download; you can read about the detail here: https://github.com/travis-ci/travis-ci/issues/6120
So, to get the repo back to green, I turned off -fllvm in the cabal for bench.
There's just one target: stack lts-6.  I figured it would be better to keep the time down until some stability is reached.