### PR TITLE
refactor of cabal file, adding flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,12 +57,12 @@ install:
   set -ex
   case "$BUILD" in
     stack)
-      stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+      stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies --flag subhask:-llvmsupport
       ;;
     cabal)
       cabal --version
       travis_retry cabal update
-      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 -f-llvmsupport $CABALARGS $PACKAGES
       ;;
   esac
   set +ex
@@ -71,10 +71,10 @@ script:
   set -ex
   case "$BUILD" in
     stack)
-      stack --no-terminal $ARGS test --bench --no-run-benchmarks
+      stack --no-terminal $ARGS test --bench --no-run-benchmarks --flag subhask:-llvmsupport
       ;;
     cabal)
-      cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS $PACKAGES
+      cabal install --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 -f-llvmsupport $CABALARGS $PACKAGES
       ORIGDIR=$(pwd)
       for dir in $PACKAGES
       do

--- a/subhask.cabal
+++ b/subhask.cabal
@@ -26,6 +26,18 @@ source-repository head
 
 --------------------------------------------------------------------------------
 
+Flag LlvmSupport
+      Description: whether to -fllvm
+      Default: True
+      -- needed to be turned off in travis.
+      -- see https://github.com/travis-ci/travis-ci/issues/6120
+
+Flag DoTestOptimise
+      Description: whether to -O2 test
+      Default: False
+      -- full optimised compilation takes a bit, and is turned off by default for the test suite.
+      -- Note: still on for the bench suite, where it doesn't take long.
+
 library
     exposed-modules:
         SubHask
@@ -98,7 +110,6 @@ library
         AutoDeriveTypeable,
         DeriveGeneric,
         RebindableSyntax
---         OverloadedLists
 
     hs-source-dirs:
         src
@@ -156,65 +167,21 @@ library
 
 --------------------------------------------------------------------------------
 
-Test-Suite TestSuite-Unoptimized
+Test-Suite test
     default-language:   Haskell2010
     type:               exitcode-stdio-1.0
     hs-source-dirs:     test
     main-is:            TestSuite.hs
-
-    ghc-options:
-        -O0
-
     build-depends:
         subhask,
         test-framework-quickcheck2,
         test-framework
+  if flag(dotestoptimise)
+    ghc-options: -O2
+  if flag(llvmsupport)
+    ghc-options: -fllvm
 
--- FIXME:
--- The test below takes a long time to compile.
--- The slow builds are causing travis tests to fail.
---
--- Test-Suite TestSuite-Optimized
---     default-language:   Haskell2010
---     type:               exitcode-stdio-1.0
---     hs-source-dirs:     test
---     main-is:            TestSuite.hs
---
---     build-depends:
---         subhask,
---         test-framework-quickcheck2  >= 0.3.0,
---         test-framework              >= 0.8.0
---
---     ghc-options:
---         -O2
---         -fllvm
-
---------------------
-
-Test-Suite Example0001
-    default-language:   Haskell2010
-    type:               exitcode-stdio-1.0
-    hs-source-dirs:     examples
-    main-is:            example0001-polynomials.lhs
-    build-depends:      subhask, base
-
-Test-Suite Example0002
-    default-language:   Haskell2010
-    type:               exitcode-stdio-1.0
-    hs-source-dirs:     examples
-    main-is:            example0002-monad-instances-for-set.lhs
-    build-depends:      subhask, base
-
-Test-Suite Example0003
-    default-language:   Haskell2010
-    type:               exitcode-stdio-1.0
-    hs-source-dirs:     examples
-    main-is:            example0003-linear-algebra.lhs
-    build-depends:      subhask, base
-
---------------------------------------------------------------------------------
-
-benchmark Vector
+benchmark bench
     default-language: Haskell2010
     type:             exitcode-stdio-1.0
     hs-source-dirs:   bench
@@ -229,10 +196,29 @@ benchmark Vector
         -O2
         -funbox-strict-fields
         -fexcess-precision
-        -- awaiting https://github.com/travis-ci/travis-ci/issues/6120
-        -- -fllvm
         -optlo-O3
         -optlo-enable-fp-mad
         -optlo-enable-no-infs-fp-math
         -optlo-enable-no-nans-fp-math
         -optlo-enable-unsafe-fp-math
+
+ if flag(llvmsupport)
+    ghc-options: -fllvm
+
+executable Example0001
+    default-language:   Haskell2010
+    hs-source-dirs:     examples
+    main-is:            example0001-polynomials.lhs
+    build-depends:      subhask, base
+
+executable Example0002
+    default-language:   Haskell2010
+    hs-source-dirs:     examples
+    main-is:            example0002-monad-instances-for-set.lhs
+    build-depends:      subhask, base
+
+executable Example0003
+    default-language:   Haskell2010
+    hs-source-dirs:     examples
+    main-is:            example0003-linear-algebra.lhs
+    build-depends:      subhask, base


### PR DESCRIPTION
- changed examples to executables
- turned llvm back on
- added cabal flags to toggle llvm, and O2 for the test suite
- moved to default target names
- travis run edited to run no llvm bench