### PR TITLE
Update to ghc 8

### DIFF
--- a/src/SubHask/SubType.hs
+++ b/src/SubHask/SubType.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE NoAutoDeriveTypeable #-} -- can't derive typeable of data families
+{-# LANGUAGE NoAutoDeriveTypeable, ExplicitNamespaces #-} -- can't derive typeable of data families
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 
 -- | This module defines the subtyping mechanisms used in subhask.
 module SubHask.SubType
-    ( (<:) (..)
+    ( type (<:) (..)
     , Sup
 
     -- **
@@ -174,6 +174,7 @@ stripForall (AppT t1 t2) = AppT (stripForall t1) (stripForall t2)
 -- FIXME: What if the type doesn't have kind *?
 mkSubtypeInstance :: Type -> Type -> Name -> Dec
 mkSubtypeInstance t1 t2 f = InstanceD
+    Nothing
     []
     ( AppT
         ( AppT
@@ -205,6 +206,6 @@ mkSubtypeInstance t1 t2 f = InstanceD
 --
 mkSup :: Type -> Type -> Type -> [Dec]
 mkSup t1 t2 t3 =
-    [ InstanceD [] (AppT (AppT (AppT (ConT $ mkName "Sup") t1) t2) t3) []
-    , InstanceD [] (AppT (AppT (AppT (ConT $ mkName "Sup") t2) t1) t3) []
+    [ InstanceD Nothing [] (AppT (AppT (AppT (ConT $ mkName "Sup") t1) t2) t3) []
+    , InstanceD Nothing [] (AppT (AppT (AppT (ConT $ mkName "Sup") t2) t1) t3) []
     ]

--- a/src/SubHask/TemplateHaskell/Deriving.hs
+++ b/src/SubHask/TemplateHaskell/Deriving.hs
@@ -93,8 +93,8 @@ deriveTypefamilies :: [Name] -> Name -> Q [Dec]
 deriveTypefamilies familynameL typename = do
     info <- reify typename
     let (tyvarbndr,tyvar) = case info of
-            TyConI (NewtypeD _ _ xs (NormalC _ [(  _,t)]) _) -> (xs,t)
-            TyConI (NewtypeD _ _ xs (RecC    _ [(_,_,t)]) _) -> (xs,t)
+            TyConI (NewtypeD _ _ xs _ (NormalC _ [(  _,t)]) _) -> (xs,t)
+            TyConI (NewtypeD _ _ xs _ (RecC    _ [(_,_,t)]) _) -> (xs,t)
     return $ map (go tyvarbndr tyvar) familynameL
     where
         go tyvarbndr tyvar familyname = TySynInstD familyname $ TySynEqn
@@ -122,10 +122,10 @@ deriveSingleInstance typename classname = if show classname == "SubHask.Mutable.
     else do
         typeinfo <- reify typename
         (conname,typekind,typeapp) <- case typeinfo of
-            TyConI (NewtypeD [] _ typekind (NormalC conname [(  _,typeapp)]) _)
+            TyConI (NewtypeD [] _ typekind _ (NormalC conname [(  _,typeapp)]) _)
                 -> return (conname,typekind,typeapp)
 
-            TyConI (NewtypeD [] _ typekind (RecC    conname [(_,_,typeapp)]) _)
+            TyConI (NewtypeD [] _ typekind _ (RecC    conname [(_,_,typeapp)]) _)
                 -> return (conname,typekind,typeapp)
 
             _ -> error $ "\nderiveSingleInstance; typeinfo="++show typeinfo
@@ -145,8 +145,8 @@ deriveSingleInstance typename classname = if show classname == "SubHask.Mutable.
             -- then don't create an overlapping instance
             -- These classes only exist because TH has problems with type families
             -- FIXME: this is probably not a robust solution
-            ClassI (ClassD _ _ _ _ _) [InstanceD _ (VarT _) _] -> return []
-            ClassI (ClassD _ _ _ _ _) [InstanceD _ (AppT (ConT _) (VarT _)) _] -> return []
+            ClassI (ClassD _ _ _ _ _) [InstanceD _ _ (VarT _) _] -> return []
+            ClassI (ClassD _ _ _ _ _) [InstanceD _ _ (AppT (ConT _) (VarT _)) _] -> return []
 
             -- otherwise, create the instance
             ClassI (ClassD ctx _ [bndr] [] decs) _ -> do
@@ -180,6 +180,7 @@ deriveSingleInstance typename classname = if show classname == "SubHask.Mutable.
                                 ]
 
                         return [ InstanceD
+                                Nothing
                                 ( AppT (ConT classname) typeapp : map (substitutePat varname typeapp) ctx )
                                 ( AppT (ConT classname) $ apply2varlist (ConT typename) typekind )
                                 ( concat funcL )
@@ -235,9 +236,10 @@ returnType2newtypeApplicator conname varname t exp' = do
             info <- reify c
             case info of
                 TyConI (TySynD _ _ _) -> expandTySyn t >>= go
-                FamilyI (FamilyD TypeFam _ _ _) _ -> id'
-                TyConI (NewtypeD _ _ _ _ _) -> liftM (AppE (VarE $ mkName "helper_liftM")) $ go t2
-                TyConI (DataD _ _ _ _ _) -> liftM (AppE (VarE $ mkName "helper_liftM")) $ go t2
+                FamilyI (OpenTypeFamilyD _) _ -> id'
+                FamilyI (ClosedTypeFamilyD _ _) _ -> id'
+                TyConI (NewtypeD _ _ _ _ _ _) -> liftM (AppE (VarE $ mkName "helper_liftM")) $ go t2
+                TyConI (DataD _ _ _ _ _ _) -> liftM (AppE (VarE $ mkName "helper_liftM")) $ go t2
                 qqq -> error $ "returnType2newtypeApplicator: qqq="++show qqq
 
         go (AppT ListT t2) = liftM (AppE (VarE $ mkName "helper_liftM")) $ go t2
@@ -264,7 +266,7 @@ isNewtypeInstance typename classname = do
     case info of
         ClassI _ inst -> return $ or $ map go inst
     where
-        go (InstanceD _ (AppT _ (AppT (ConT n) _)) _) = n==typename
+        go (InstanceD _ _ (AppT _ (AppT (ConT n) _)) _) = n==typename
         go _ = False
 
 
@@ -317,6 +319,7 @@ fromPreludeEq qt = do
             ( mkName "Logic" )
             ( TySynEqn [t] (ConT $ mkName "Bool" ))
         , InstanceD
+            Nothing
             []
             ( AppT ( ConT $ mkName "Eq_" ) t )
             [ FunD

--- a/src/SubHask/TemplateHaskell/Mutable.hs
+++ b/src/SubHask/TemplateHaskell/Mutable.hs
@@ -49,9 +49,9 @@ mkMutableNewtype :: Name -> Q [Dec]
 mkMutableNewtype typename = do
     typeinfo <- reify typename
     (conname,typekind,typeapp) <- case typeinfo of
-        TyConI (NewtypeD [] _ typekind (NormalC conname [(  _,typeapp)]) _)
+        TyConI (NewtypeD [] _ typekind _ (NormalC conname [(  _,typeapp)]) _)
             -> return (conname,typekind,typeapp)
-        TyConI (NewtypeD [] _ typekind (RecC    conname [(_,_,typeapp)]) _)
+        TyConI (NewtypeD [] _ typekind _ (RecC    conname [(_,_,typeapp)]) _)
             -> return (conname,typekind,typeapp)
         _ -> error $ "\nderiveSingleInstance; typeinfo="++show typeinfo
 
@@ -65,9 +65,10 @@ mkMutableNewtype typename = do
                 [ ]
                 ( mkName $ "Mutable" )
                 [ VarT (mkName "m"), apply2varlist (ConT typename) typekind ]
+                Nothing
                 ( NormalC
                     mutname
-                    [( NotStrict
+                    [( (Bang NoSourceUnpackedness NoSourceStrictness)
                      , AppT
                         ( AppT
                             ( ConT $ mkName "Mutable" )
@@ -78,6 +79,7 @@ mkMutableNewtype typename = do
                 )
                 [ ]
             , InstanceD
+                Nothing
                 ( map (\x -> AppT (ConT $ mkName "IsMutable") (bndr2type x)) $ filter isStar $ typekind )
                 ( AppT
                     ( ConT $ mkName "IsMutable" )
@@ -129,14 +131,16 @@ mkMutablePrimRef qt = do
             cxt'
             ( mkName $ "Mutable" )
             [ VarT (mkName "m"), t ]
+            Nothing
             ( NormalC
                 ( type2name t )
-                [( NotStrict
+                [( (Bang NoSourceUnpackedness NoSourceStrictness)
                  , AppT (AppT (ConT $ mkName "PrimRef") (VarT $ mkName "m")) t
                  )]
             )
             [ ]
         , InstanceD
+            Nothing
             cxt'
             ( AppT ( ConT $ mkName "IsMutable" ) t )
             [ FunD (mkName "freeze")

--- a/src/SubHask/TemplateHaskell/Test.hs
+++ b/src/SubHask/TemplateHaskell/Test.hs
@@ -227,7 +227,7 @@ mkClassTests className = do
         ( typeTests )
     where
         go [] = return $ ConE $ mkName "[]"
-        go ((InstanceD _ (AppT _ t) _):xs) = case t of
+        go ((InstanceD _ _ (AppT _ t) _):xs) = case t of
             (ConT a) -> do
                 tests <- mkSpecializedClassTest (ConT a) className
                 next <- go xs
@@ -290,7 +290,7 @@ specializeLaw
 specializeLaw typeName lawName = do
     lawInfo <- reify lawName
     let newType = case lawInfo of
-            VarI _ t _ _ -> specializeType t typeName
+            VarI _ t _ -> specializeType t typeName
             _ -> error "mkTest lawName not a function"
     return $ SigE (VarE lawName) newType
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,8 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-    [ gamma-0.9.0.2
-    , continued-fractions-0.9.1.1
-    , converge-0.1.0.1
-    ]
-resolver: lts-6.3
+- gamma-0.9.0.2
+- continued-fractions-0.9.1.1
+- converge-0.1.0.1
+- monad-primitive-0.1
+resolver: lts-9.1

--- a/subhask.cabal
+++ b/subhask.cabal
@@ -127,7 +127,7 @@ library
 
     build-depends:
         -- haskell language
-        base >= 4.8 && <4.9,
+        base >= 4.8 && <4.10,
         ghc-prim,
         template-haskell,
 
@@ -161,7 +161,7 @@ library
         semigroups,
         bytes,
         approximate,
-        lens                 
+        lens
 
     default-language:
         Haskell2010


### PR DESCRIPTION
I've been trying to compile HLearn on a more recent GHC release. Since it depends on subhask, I need to get that compiling first! I've gotten most of the modules compiling.

The current issue is related to the `Monoidal` category class:

```
/Users/xavier/Code/mikeizbicki/subhask/src/SubHask/Category.hs:268:27: error:
    • Expected a type, but ‘TUnit cat’ has kind ‘k’
    • In the type signature:
        tunit :: proxy cat -> TUnit cat
      In the class declaration for ‘Monoidal’
```

for reference:

```haskell
    type TUnit cat :: k
    tunit :: proxy cat -> TUnit cat
```

I don't understand how this was working  before since all values are of kind `*`?